### PR TITLE
Add ability to assign a firewall

### DIFF
--- a/apps/manual-kafka-cluster/provision.yml
+++ b/apps/manual-kafka-cluster/provision.yml
@@ -8,7 +8,16 @@
   
   tasks:
 
+  - name: get firewall info
+    # https://galaxy.ansible.com/ui/repo/published/linode/cloud/content/module/firewall_info/
+    linode.cloud.firewall_info:
+      label: '{{ firewall_label }}'
+      api_token: '{{ api_token }}'
+    register: firewall_info
+    when: firewall_label|d(False)
+
   - name: creating kafka servers
+    # https://galaxy.ansible.com/ui/repo/published/linode/cloud/content/module/instance/
     linode.cloud.instance:
       label: '{{ instance_prefix }}{{ item }}'
       api_token: '{{ api_token }}'
@@ -21,6 +30,7 @@
       ua_prefix: 'docs-kafka-occ'          
       tags: '{{ linode_tags }}'
       state: present
+      firewall_id: '{{ (firewall_info.firewall|default({})).id|default(omit) }}'
     with_sequence: count='{{ cluster_size }}'
 
   - name: get info about the instances


### PR DESCRIPTION
We can assign a firewall to newly created linodes if the user sets a firewall_label in `vars`